### PR TITLE
Fix an error in chinese-word-at-point-bounds

### DIFF
--- a/chinese-word-at-point.el
+++ b/chinese-word-at-point.el
@@ -79,8 +79,8 @@ Return Chinese words as a string separated by one space"
                (current-pos (point))
                (index beginning-pos)
                (old-index beginning-pos))
-          (dolist (word (split-string (chinese-word--split-by-space
-                                       current-word)))
+          (cl-dolist (word (split-string (chinese-word--split-by-space
+                                          current-word)))
             (cl-incf index (length word))
             (if (and (>= current-pos old-index)
                      (< current-pos index))


### PR DESCRIPTION
Replace stray dolist with cl-dolist. The builtin dolist doesn't catch
throws from cl-return, which leads to an error.